### PR TITLE
Add module merging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,15 @@
 plugins {
-    id 'org.ajoberstar.grgit' version '4.1.0'
+    id 'net.minecraftforge.gradleutils' version '1.+'
     id 'com.github.ben-manes.versions' version '0.38.0'
-    id 'org.javamodularity.moduleplugin' version '1.8.3' apply false
+    id 'org.javamodularity.moduleplugin' version '1.8.3'
+    id 'java-library'
+    id 'maven-publish'
+    id 'eclipse'
 }
-
-apply plugin: 'java-library'
-apply plugin: 'maven-publish'
-apply plugin: 'eclipse'
-apply plugin: 'org.javamodularity.moduleplugin'
 
 group 'cpw.mods'
 
-version = grgit.describe(longDescr: true).split('-').with { "${it[0]}.${it[1]}" }
+version = gradleutils.getTagOffsetVersion()
 logger.lifecycle('Version: ' + version)
 
 repositories {
@@ -38,11 +36,11 @@ jar {
                 'Specification-Vendor': 'forge',
                 'Specification-Version': '1', // We are version 1 of ourselves
                 'Implementation-Title': project.name,
-                'Implementation-Version': "${project.version}+${System.getenv("BUILD_NUMBER")?:0}+${grgit.branch.current().getName()}.${grgit.head().abbreviatedId}",
+                'Implementation-Version': "${project.version}+${System.getenv("BUILD_NUMBER")?:0}+${gradleutils.gitInfo.branch}.${gradleutils.gitInfo.abbreviatedId}",
                 'Implementation-Vendor':'forge',
                 'Implementation-Timestamp': java.time.Instant.now().toString(),
-                'Git-Commit': grgit.head().abbreviatedId,
-                'Git-Branch': grgit.branch.current().getName(),
+                'Git-Commit': gradleutils.gitInfo.abbreviatedId,
+                'Git-Branch': gradleutils.gitInfo.branch,
                 'Build-Number': "${System.getenv("BUILD_NUMBER")?:0}",
                 'Main-Class': 'cpw.mods.bootstraplauncher.BootstrapLauncher'
         )
@@ -84,14 +82,18 @@ publishing {
     }
     repositories {
         maven {
-            authentication {
-                basic(BasicAuthentication)
+            if (System.env.MAVEN_USER) {
+                authentication {
+                    basic(BasicAuthentication)
+                }
+                credentials {
+                    username = System.env.MAVEN_USER ?: 'not'
+                    password = System.env.MAVEN_PASSWORD ?: 'set'
+                }
+                url 'https://maven.minecraftforge.net/releases'
+            } else {
+                url 'file://' + rootProject.file('repo').getAbsolutePath()
             }
-            credentials {
-                username = System.env.MAVEN_USER ?: 'not'
-                password = System.env.MAVEN_PASSWORD ?: 'set'
-            }
-            url 'https://maven.minecraftforge.net/releases'
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
     }
 }
 dependencies {
-    implementation('cpw.mods:securejarhandler:0.9.33')
+    implementation('cpw.mods:securejarhandler:0.9.44')
 }
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,9 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        maven { url = 'https://maven.minecraftforge.net/' }
+    }
+}
+
 rootProject.name = 'bootstraplauncher'
 

--- a/src/main/java/cpw/mods/bootstraplauncher/BootstrapLauncher.java
+++ b/src/main/java/cpw/mods/bootstraplauncher/BootstrapLauncher.java
@@ -3,6 +3,7 @@ package cpw.mods.bootstraplauncher;
 import cpw.mods.cl.JarModuleFinder;
 import cpw.mods.cl.ModuleClassLoader;
 import cpw.mods.jarhandling.SecureJar;
+import cpw.mods.jarhandling.impl.SimpleJarMetadata;
 
 import java.io.File;
 import java.lang.module.ModuleFinder;
@@ -10,6 +11,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -17,13 +19,14 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class BootstrapLauncher {
     private static final boolean DEBUG = System.getProperties().containsKey("bsl.debug");
     @SuppressWarnings("unchecked")
     public static void main(String[] args) {
-        var legacyCP = Objects.requireNonNull(System.getProperty("legacyClassPath"), "Missing legacyClassPath, cannot bootstrap");
+        var legacyCP = Objects.requireNonNull(System.getProperty("legacyClassPath", System.getProperty("java.class.path")), "Missing legacyClassPath, cannot bootstrap");
         var ignoreList = System.getProperty("ignoreList", "/org/ow2/asm/,securejarhandler"); //TODO: find existing modules automatically instead of taking in an ignore list.
         var ignores = ignoreList.split(",");
 
@@ -31,7 +34,7 @@ public class BootstrapLauncher {
         var jars = new ArrayList<>();
 
         outer:
-        for  (var legacy : legacyCP.split(File.pathSeparator)) {
+        for (var legacy : legacyCP.split(File.pathSeparator)) {
             for (var filter : ignores) {
                 if (legacy.contains(filter)) {
                     if (DEBUG)
@@ -42,7 +45,7 @@ public class BootstrapLauncher {
 
             var path = Paths.get(legacy);
             if (DEBUG)
-                System.out.println(path.toString());
+                System.out.println(path);
             var jar = SecureJar.from(new PkgTracker(Set.copyOf(previousPkgs), path), path);
             var pkgs = jar.getPackages();
             if (DEBUG)
@@ -50,7 +53,7 @@ public class BootstrapLauncher {
             previousPkgs.addAll(pkgs);
             jars.add(jar);
         }
-        var finder = jars.toArray(SecureJar[]::new);
+        var finder = mergeModules(jars.toArray(SecureJar[]::new));
 
         var alltargets = Arrays.stream(finder).map(SecureJar::name).toList();
         var jf = JarModuleFinder.of(finder);
@@ -63,6 +66,27 @@ public class BootstrapLauncher {
         final var loader = ServiceLoader.load(layer.layer(), Consumer.class);
         // This *should* find the service exposed by ModLauncher's BootstrapLaunchConsumer {This doc is here to help find that class next time we go looking}
         ((Consumer<String[]>)loader.stream().findFirst().orElseThrow().get()).accept(args);
+    }
+
+    private static SecureJar[] mergeModules(SecureJar[] finder) {
+        // newModule=module1,module2;otherModule=module3,module4
+        var mergeModules = System.getProperty("mergeModules");
+        if (mergeModules == null)
+            return finder;
+
+        var moduleMap = Arrays.stream(finder).collect(Collectors.toMap(SecureJar::name, Function.identity()));
+        for (var merge : mergeModules.split(";")) {
+            var split = merge.split("=");
+            var key = split[0];
+            var targets = Arrays.stream(split[1].split(",")).map(moduleMap::remove).filter(Objects::nonNull).toList();
+            var filter = targets.stream().map(SecureJar::getPathFilter).reduce(BiPredicate::or).orElseThrow();
+            var paths = targets.stream().map(SecureJar::getPrimaryPath).toArray(Path[]::new);
+
+            var newJar = SecureJar.from(sj -> new SimpleJarMetadata(key, null, sj.getPackages(), sj.getProviders()), filter, paths);
+            moduleMap.put(key, newJar);
+        }
+
+        return moduleMap.values().toArray(SecureJar[]::new);
     }
 
     private record PkgTracker(Set<String> packages, Path paths) implements BiPredicate<String, String> {

--- a/src/main/java/cpw/mods/bootstraplauncher/BootstrapLauncher.java
+++ b/src/main/java/cpw/mods/bootstraplauncher/BootstrapLauncher.java
@@ -31,7 +31,7 @@ public class BootstrapLauncher {
         var previousPkgs = new HashSet<String>();
         var jars = new ArrayList<>();
         var filenameMap = getMergeFilenameMap();
-        var mergeMap = new HashMap<String, List<Path>>();
+        var mergeMap = new HashMap<Integer, List<Path>>();
 
         outer:
         for (var legacy : legacyCP.split(File.pathSeparator)) {
@@ -58,7 +58,7 @@ public class BootstrapLauncher {
             previousPkgs.addAll(pkgs);
             jars.add(jar);
         }
-        mergeMap.forEach((modulename, paths) -> {
+        mergeMap.forEach((idx, paths) -> {
             var pathsArray = paths.toArray(Path[]::new);
             var jar = SecureJar.from(new PkgTracker(Set.copyOf(previousPkgs), pathsArray), pathsArray);
             var pkgs = jar.getPackages();
@@ -84,20 +84,22 @@ public class BootstrapLauncher {
         ((Consumer<String[]>)loader.stream().findFirst().orElseThrow().get()).accept(args);
     }
 
-    private static Map<String, String> getMergeFilenameMap() {
-        // newModule=filename1.jar,filename2.jar;otherModule=filename2.jar,filename3.jar
+    private static Map<String, Integer> getMergeFilenameMap() {
+        // filename1.jar,filename2.jar;otherModule=filename2.jar,filename3.jar
         var mergeModules = System.getProperty("mergeModules");
         if (mergeModules == null)
             return Map.of();
 
-        Map<String, String> filenameMap = new HashMap<>();
+        Map<String, Integer> filenameMap = new HashMap<>();
+        int i = 0;
         for (var merge : mergeModules.split(";")) {
             var split = merge.split("=");
             var key = split[0];
             var targets = split[1].split(",");
             for (String target : targets) {
-                filenameMap.put(target, key);
+                filenameMap.put(target, i);
             }
+            i++;
         }
 
         return filenameMap;


### PR DESCRIPTION
This PR adds a new optional system property to support merging modules before they are configured and resolved in the bootstrap layer. This allows for merging modules with conflicting packages which are still needed and not critical to have as separate modules. The PR also moves from grgit to GradleUtils and Gradle 7.1.1.

This PR is waiting on https://github.com/MinecraftForge/securejarhandler/pull/2 to be pulled, assuming it gets built as 0.9.44 then this can be merged afterwards.