### PR TITLE
Add support for loading the legacy classpath from a file.

### DIFF
--- a/src/main/java/cpw/mods/bootstraplauncher/BootstrapLauncher.java
+++ b/src/main/java/cpw/mods/bootstraplauncher/BootstrapLauncher.java
@@ -29,8 +29,7 @@ public class BootstrapLauncher {
     @SuppressWarnings("unchecked")
     public static void main(String[] args) {
         var legacyCP = loadLegacyClassPath();
-        System.setProperty("legacyClassPath",
-          String.join(File.pathSeparator, legacyCP)); //Ensure backwards compatibility if somebody reads this value later on.
+        System.setProperty("legacyClassPath", String.join(File.pathSeparator, legacyCP)); //Ensure backwards compatibility if somebody reads this value later on.
         var ignoreList = System.getProperty("ignoreList", "/org/ow2/asm/,securejarhandler"); //TODO: find existing modules automatically instead of taking in an ignore list.
         var ignores = ignoreList.split(",");
 
@@ -129,12 +128,10 @@ public class BootstrapLauncher {
         if (legacyCpPath != null) {
             var legacyCPFileCandidatePath = Paths.get(legacyCpPath);
             if (Files.exists(legacyCPFileCandidatePath) && Files.isRegularFile(legacyCPFileCandidatePath)) {
-                try
-                {
+                try {
                     return Files.readAllLines(legacyCPFileCandidatePath);
                 }
-                catch (IOException e)
-                {
+                catch (IOException e) {
                     throw new IllegalStateException("Failed to load the legacy class path from the specified file: " + legacyCpPath, e);
                 }
             }

--- a/src/main/java/cpw/mods/bootstraplauncher/BootstrapLauncher.java
+++ b/src/main/java/cpw/mods/bootstraplauncher/BootstrapLauncher.java
@@ -121,21 +121,19 @@ public class BootstrapLauncher {
     }
 
     private static String loadLegacyClassPath() {
-        var legacyCpPath = System.getProperty("legacyClassPath.file", "NOT_DEFINED");
+        var legacyCpPath = System.getProperty("legacyClassPath.file");
 
-        if (legacyCpPath.equals("NOT_DEFINED")) {
-            return Objects.requireNonNull(System.getProperty("legacyClassPath", System.getProperty("java.class.path")), "Missing legacyClassPath, cannot bootstrap");
-        }
-
-        var legacyCPFileCandidatePath = Paths.get(legacyCpPath);
-        if (Files.exists(legacyCPFileCandidatePath) && Files.isRegularFile(legacyCPFileCandidatePath)) {
-            try
-            {
-                return Files.readString(legacyCPFileCandidatePath);
-            }
-            catch (IOException e)
-            {
-                throw new IllegalStateException("Failed to load the legacy class path from the specified file: " + legacyCpPath, e);
+        if (legacyCpPath != null) {
+            var legacyCPFileCandidatePath = Paths.get(legacyCpPath);
+            if (Files.exists(legacyCPFileCandidatePath) && Files.isRegularFile(legacyCPFileCandidatePath)) {
+                try
+                {
+                    return Files.readString(legacyCPFileCandidatePath);
+                }
+                catch (IOException e)
+                {
+                    throw new IllegalStateException("Failed to load the legacy class path from the specified file: " + legacyCpPath, e);
+                }
             }
         }
 


### PR DESCRIPTION
This adds support for loading the legacy classpath from a file.

This allows IDE to start dev instances where the legacy classpath is too long to be passed as a launch argument.